### PR TITLE
Security Fix: Hardcoded API Key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+BREVO_API_KEY=your_brevo_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # local env files
+.env
 .env*.local
 
 # vercel

--- a/utils/services/emailService.js
+++ b/utils/services/emailService.js
@@ -5,7 +5,6 @@ const brevo_key = process.env.NEXT_PUBLIC_BREVO_API_KEY;
 
 export const sendEmail = async (email) => {
   try {
-    // Check if API key is available
     if (!brevo_key) {
       console.error("Brevo API key is not configured");
       notify("Email service configuration error", "error");

--- a/utils/services/emailService.js
+++ b/utils/services/emailService.js
@@ -1,9 +1,17 @@
 import axios from "axios";
 import { notify } from "./notification";
-const brevo_key = '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';
+
+const brevo_key = process.env.NEXT_PUBLIC_BREVO_API_KEY;
 
 export const sendEmail = async (email) => {
   try {
+    // Check if API key is available
+    if (!brevo_key) {
+      console.error("Brevo API key is not configured");
+      notify("Email service configuration error", "error");
+      return;
+    }
+
     if (validateEmail(email)) {
       const options = {
         method: "POST",


### PR DESCRIPTION
Removed the hardcoded Brevo API with its environment variable. Requesting maintainers to generate a new API key through the Brevo API dashboard and add the env variable in the Vercel's deployment.

I will open up a follow up PR to move the email sending logic to server side.