### PR TITLE
Refactor email service to be handled server side

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_BREVO_API_KEY=your_brevo_api_key_here
+NEXT_PUBLIC_BREVO_API=your_brevo_api_key_here

--- a/pages/api/send-email.js
+++ b/pages/api/send-email.js
@@ -1,0 +1,53 @@
+import axios from "axios";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
+  const { email } = req.body;
+  const brevo_key = process.env.NEXT_PUBLIC_BREVO_API;
+
+  if (!brevo_key) {
+    return res.status(500).json({ error: "Brevo API key is not configured" });
+  }
+
+  if (!email || !validateEmail(email)) {
+    return res.status(400).json({ error: "Invalid email address" });
+  }
+
+  const options = {
+    method: "POST",
+    url: "https://api.brevo.com/v3/smtp/email",
+    headers: {
+      accept: "application/json",
+      "content-type": "application/json",
+      "api-key": brevo_key,
+    },
+    data: {
+      sender: {
+        name: "Lighthouse",
+        email: "hello@lighthouseweb3.xyz",
+      },
+      to: [{ email }],
+      templateId: 4,
+      tags: ["mainsite-subscription"],
+    },
+  };
+
+  try {
+    await axios.request(options);
+    return res.status(200).json({ message: "Email Submitted" });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ error: "Failed to send email" });
+  }
+}
+
+function validateEmail(email) {
+  return String(email)
+    .toLowerCase()
+    .match(
+      /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+    );
+}

--- a/utils/services/emailService.js
+++ b/utils/services/emailService.js
@@ -5,45 +5,23 @@ const brevo_key = process.env.NEXT_PUBLIC_BREVO_API;
 
 export const sendEmail = async (email) => {
   try {
-    if (!brevo_key) {
-      console.error("Brevo API key is not configured");
-      notify("Email service configuration error", "error");
+    if (!validateEmail(email)) {
+      notify(`Error: Enter a valid email address`, "error");
       return;
     }
 
-    if (validateEmail(email)) {
-      const options = {
-        method: "POST",
-        url: "https://api.brevo.com/v3/smtp/email",
-        headers: {
-          accept: "application/json",
-          "content-type": "application/json",
-          "api-key": brevo_key,
-        },
-        data: {
-          sender: {
-            name: "Lighthouse",
-            email: "hello@lighthouseweb3.xyz",
-          },
-          to: [{ email }],
-          templateId: 4,
-          tags: ["mainsite-subscription"],
-        },
-      };
-
-      axios
-        .request(options)
-        .then(function (response) {
-          //
-          notify("Email Submitted", "success");
-        })
-        .catch(function (error) {
-          console.error(error);
-        });
+    const response = await axios.post("/api/send-email", { email });
+    if (response.status === 200) {
+      notify("Email Submitted", "success");
     } else {
-      notify(`Error: Enter a valid email address`, "error");
+      notify("Failed to send email", "error");
     }
   } catch (error) {
+    if (error.response && error.response.data && error.response.data.error) {
+      notify(error.response.data.error, "error");
+    } else {
+      notify("Failed to send email", "error");
+    }
     console.error(error);
   }
 };


### PR DESCRIPTION
The email sending logic has been moved to a secure server-side API route at ```send-email.js```. The client-side sendEmail function now calls this API route, so your API key is no longer exposed to the client.

In Next.js, any environment variable prefixed with NEXT_PUBLIC_ is embedded into the client-side JavaScript bundle and is accessible in the browser. This means anyone inspecting  frontend code could see the API key